### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ StyleShift leverages generative AI to transform your images. You can:
 *   Select different artistic styles (e.g., Abstract, Surreal, Cyberpunk).
 *   Generate a new, restyled image based on your selections.
 *   Download the restyled image.
+*   Toggle between light and dark themes.
 
 ## Tech Stack
 

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -9,6 +9,7 @@
 - Restyling AI: The OpenAI LLM applies the chosen emotional and stylistic adjustments to the uploaded image; it uses a tool to decide when or whether to apply the requested parameters based on an evaluation of how to generate the highest quality output..
 - Image Display: The restyled image is sent back to the app and displayed to the user.
 - Image Download: Allows users to download the newly created image.
+- Dark Mode Toggle: Users can switch between light and dark themes.
 
 ## Style Guidelines:
 

--- a/src/components/core/app-header.tsx
+++ b/src/components/core/app-header.tsx
@@ -1,4 +1,5 @@
 import { StyleShiftLogo } from '@/components/core/styleshift-logo';
+import { ThemeToggle } from '@/components/core/theme-toggle';
 
 export function AppHeader() {
   return (
@@ -10,7 +11,7 @@ export function AppHeader() {
             StyleShift
           </h1>
         </div>
-        {/* Future navigation or actions can go here */}
+        <ThemeToggle />
       </div>
     </header>
   );

--- a/src/components/core/theme-toggle.tsx
+++ b/src/components/core/theme-toggle.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { Moon, Sun } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useTheme } from '@/hooks/use-theme';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme">
+      {theme === 'dark' ? <Sun className="h-6 w-6" /> : <Moon className="h-6 w-6" />}
+    </Button>
+  );
+}

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'theme';
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  // Set initial theme from localStorage or system preference
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) as Theme | null : null;
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+  }, []);
+
+  // Apply theme to document root and persist
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      /* ignore */
+    }
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+
+  return { theme, setTheme, toggleTheme };
+}


### PR DESCRIPTION
## Summary
- add `useTheme` hook for managing light/dark mode
- add `ThemeToggle` component
- integrate the toggle in `AppHeader`
- document dark mode feature in README and blueprint

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6854ea2579d0832280e1d423de185ffa